### PR TITLE
Re-use NavigationCheck logic

### DIFF
--- a/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/controllers/enterprise_controller.js.coffee
@@ -1,5 +1,5 @@
 angular.module("admin.enterprises")
-  .controller "enterpriseCtrl", ($scope, $window, NavigationCheck, FormState, enterprise, EnterprisePaymentMethods, EnterpriseShippingMethods, SideMenu, StatusMessage) ->
+  .controller "enterpriseCtrl", ($scope, $window, NavigationCheck, enterprise, EnterprisePaymentMethods, EnterpriseShippingMethods, SideMenu, StatusMessage) ->
     $scope.Enterprise = enterprise
     $scope.PaymentMethods = EnterprisePaymentMethods.paymentMethods
     $scope.ShippingMethods = EnterpriseShippingMethods.shippingMethods
@@ -11,8 +11,7 @@ angular.module("admin.enterprises")
     $scope.StatusMessage = StatusMessage
 
     $scope.$watch 'enterprise_form.$dirty', (newValue) ->
-      FormState.isDirty = newValue
-      StatusMessage.display 'notice', 'You have unsaved changes' if newValue
+      StatusMessage.display 'notice', t('admin.unsaved_changes') if newValue
 
     $scope.setFormDirty = ->
       $scope.$apply ->
@@ -29,7 +28,7 @@ angular.module("admin.enterprises")
     # from a directive "nav-check" in the page - if we pass it here it will be called in the test suite,
     # and on all new uses of this contoller, and we might not want that.
     enterpriseNavCallback = ->
-      if FormState.isDirty
+      if $scope.enterprise_form.$dirty
         t('admin.unsaved_confirm_leave')
 
     # Register the NavigationCheck callback

--- a/app/assets/javascripts/admin/enterprises/directives/enterprise_switcher.js.coffee
+++ b/app/assets/javascripts/admin/enterprises/directives/enterprise_switcher.js.coffee
@@ -1,22 +1,16 @@
-angular.module('admin.enterprises').directive 'enterpriseSwitcher',
-  ['FormState','NavigationCheck', (FormState, NavigationCheck) ->
-    restrict: 'A'
-    require: 'ngModel'
-    link: (scope, element, attr, ngModel) ->
-      initial = element[0].getAttribute('data-initial')
-      confirm_message = t('admin.unsaved_confirm_leave')
+angular.module('admin.enterprises').directive 'enterpriseSwitcher', (NavigationCheck) ->
+  restrict: 'A'
+  require: 'ngModel'
+  link: (scope, element, attr, ngModel) ->
+    initial = element[0].getAttribute('data-initial')
 
-      element.on 'change', ->
-        if FormState.isDirty
-          #Confirm if form is dirty
-          if !confirm(confirm_message)
-            #Reset the current dropdown selection if staying on page
-            ngModel.$setViewValue initial
-            ngModel.$render()
-            element.select2 'val', initial
-            return
+    element.on 'change', ->
+      if not NavigationCheck.confirmLeave()
+        # Reset the current dropdown selection if staying on page
+        ngModel.$setViewValue initial
+        ngModel.$render()
+        element.select2 'val', initial
+        return
 
-        NavigationCheck.clear() #Don't ask twice if leaving
-        window.location = element[0].querySelector('option[selected]').getAttribute('data-url')
-
-  ]
+      NavigationCheck.clear() # Don't ask twice if leaving
+      window.location = element[0].querySelector('option[selected]').getAttribute('data-url')

--- a/app/assets/javascripts/admin/utils/services/form_state.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/form_state.js.coffee
@@ -1,3 +1,0 @@
-angular.module('admin.utils').service 'FormState', ->
-#Simple service to share form state across different controllers/scopes
-  { isDirty: false }

--- a/app/assets/javascripts/admin/utils/services/navigation_check.js.coffee
+++ b/app/assets/javascripts/admin/utils/services/navigation_check.js.coffee
@@ -20,12 +20,16 @@ angular.module("admin.utils")
 
       # Action for angular navigation.
       locationChangeStartHandler: ($event) =>
-        message = @getMessage()
-        if message and not $window.confirm(message)
+        if not @confirmLeave()
           $event.stopPropagation() if $event.stopPropagation
           $event.preventDefault() if $event.preventDefault
           $event.cancelBubble = true
           $event.returnValue = false
+
+      # Check if leaving is okay
+      confirmLeave: =>
+        message = @getMessage()
+        !message or $window.confirm(message)
 
       # Runs callback functions to retreive most recently added non-empty message.
       getMessage: ->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,7 @@ en:
     has_n_rules: "has %{num} rules"
 
     unsaved_confirm_leave: "There are unsaved changed on this page. Continue without saving?"
+    unsaved_changes: "You have unsaved changes"
 
     customers:
       index:


### PR DESCRIPTION
The enterprise switcher now uses the same code as NavigationCheck to
confirm leaving a changed form. This makes FormState obsolete.
