### PR TITLE
Revert removed translations for Enterprise mails

### DIFF
--- a/app/views/enterprise_mailer/welcome.html.haml
+++ b/app/views/enterprise_mailer/welcome.html.haml
@@ -13,7 +13,7 @@
   = t :email_admin_html, link: link_to('Admin Panel', spree.admin_url)
 
 %p
-  = t :email_community_html, link: link_to(t(:join_the_community), ContentConfig.community_forum_url)
+  = t :email_community_html, link: link_to(t(:join_community), ContentConfig.community_forum_url)
 
 %p
   = t :email_help

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -985,8 +985,13 @@ en:
   join_community: "Join the community"
   email_help: "If you have any difficulties, check out our FAQs, browse the forum or post a 'Support' topic and someone will help you out!"
   email_confirmation_activate_account: "Before we can activate your new account, we need to confirm your email address."
+  email_confirmation_greeting: "Hi, %{contact}!"
+  email_confirmation_profile_created: "A profile for %{name} has been successfully created!
+To activate your Profile we need to confirm this email address."
   email_confirmation_click_link: "Please click the link below to confirm your email and to continue setting up your profile."
   email_confirmation_link_label: "Confirm this email address »"
+  email_confirmation_help_html: "After confirming your email you can access your administration account for this enterprise.
+See the %{link} to find out more about %{sitename}'s features and to start using your profile or online store."
   email_social: "Connect with Us:"
   email_contact: "Email us:"
   email_signoff: "Cheers,"


### PR DESCRIPTION
Added translations I removed when thinking enterprise mails were already gone.
Fixed a translation key too, in one of these mails that will probably be gone next month so it's probably the least useful fix I could do (still the key was translated in 7 languages!)